### PR TITLE
一些小优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.idea
 # C extensions
 *.so
 


### PR DESCRIPTION
精简启动代码，从python直接运行mitm服务，增加纯python解析protobuf的选项，避免本地安装过更高版本protobuf时报错。
启动方式：python .\src\main.py