### PR TITLE
Update common.py

### DIFF
--- a/mhm/common.py
+++ b/mhm/common.py
@@ -53,7 +53,7 @@ def main():
             loop.create_task(start_proxy())
             logger.info(f"[i]mitmdump launched @ {len(conf['mitmdump']['mode'])} mode")
 
-        if "proxinject" in conf:
+        if conf.get("proxinject", None):
             loop.create_task(start_inject())
             logger.info(f"[i]proxinject launched @ {conf['proxinject']['set-proxy']}")
 


### PR DESCRIPTION
Always make `proxinject` optional so that the project can be run in non-Windows environment, or let people to be able to hook the proxy manually.
In this case, it's good to let configuration entry `{"proxinject": null}` to be meaningful, this allows to mark this feature as explicitly disabled.