### PR TITLE
Add '.lq.FastTest.enterGame' for game_restore

### DIFF
--- a/mhm/protocol.py
+++ b/mhm/protocol.py
@@ -99,7 +99,7 @@ def parse(id4flow: str, content: bytes) -> GameMessage:
 
             match name:
                 # TODO: _MESSAGE_TYPE_MAP support multiple name matching
-                case ".lq.FastTest.syncGame" | '.lq.FastTest.enterGame':
+                case ".lq.FastTest.syncGame" | ".lq.FastTest.enterGame":
                     for action in data["game_restore"]["actions"]:
                         _base = _MESSAGE_TYPE_MAP[f".lq.{action['name']}"]()  # HACK
                         _data = _parsedict(_base, base64.b64decode(action["data"]))

--- a/mhm/protocol.py
+++ b/mhm/protocol.py
@@ -100,10 +100,11 @@ def parse(id4flow: str, content: bytes) -> GameMessage:
             match name:
                 # TODO: _MESSAGE_TYPE_MAP support multiple name matching
                 case ".lq.FastTest.syncGame" | ".lq.FastTest.enterGame":
-                    for action in data["game_restore"]["actions"]:
-                        _base = _MESSAGE_TYPE_MAP[f".lq.{action['name']}"]()  # HACK
-                        _data = _parsedict(_base, base64.b64decode(action["data"]))
-                        action["data"] = _data
+                    if "game_restore" in data:
+                        for action in data["game_restore"]["actions"]:
+                            _base = _MESSAGE_TYPE_MAP[f".lq.{action['name']}"]()  # HACK
+                            _data = _parsedict(_base, base64.b64decode(action["data"]))
+                            action["data"] = _data
 
     return GameMessage(idx=idx, name=name, data=data, base=base, kind=kind)
 

--- a/mhm/protocol.py
+++ b/mhm/protocol.py
@@ -99,7 +99,7 @@ def parse(id4flow: str, content: bytes) -> GameMessage:
 
             match name:
                 # TODO: _MESSAGE_TYPE_MAP support multiple name matching
-                case ".lq.FastTest.syncGame":
+                case ".lq.FastTest.syncGame" | '.lq.FastTest.enterGame':
                     for action in data["game_restore"]["actions"]:
                         _base = _MESSAGE_TYPE_MAP[f".lq.{action['name']}"]()  # HACK
                         _data = _parsedict(_base, base64.b64decode(action["data"]))


### PR DESCRIPTION
如果在對局開始後花費了一段時間(例如加載人物)才進入對局，那麼`.lq.FastTest.enterGame`有可能data['step'] != 0，此時`.lq.FastTest.enterGame`的data內也會有"gameRestore"，處理方式和`.lq.FastTest.syncGame`一樣。

https://github.com/anosora233/majsoul-hook-mitm/blob/6062b6a7690f36b2c097270f7b1032ce36d1aeae/mhm/protocol.py#L100-L106
